### PR TITLE
Fix Example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
     <a href="https://github.com/victrme/pocket-editor">Github</a> - 
     <a href="https://www.npmjs.com/package/pocket-editor">Npm</a> - 
-    <a href="https://pocketeditor.netlify.app/">Example</a>
+    <a href="https://pocketeditor.victr.me/">Example</a>
 </p>
 
 <br />


### PR DESCRIPTION
Replaced the broken `Example` link with the latest working one. 